### PR TITLE
Implement grunt-watch-exec

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,16 +2,19 @@
  * grunt-watch-exec
  * https://github.com/sqm/grunt-watch-exec
  *
- * Copyright (c) 2015 Gale Shafer
+ * Copyright (c) 2015 Squaremouth
  * Licensed under the MIT license.
  */
 
 'use strict';
 
 module.exports = function(grunt) {
-
-  // Project configuration.
   grunt.initConfig({
+    // Before generating any new files, remove any previously-created files.
+    clean: {
+      tests: ['tmp']
+    },
+
     jshint: {
       all: [
         'Gruntfile.js',
@@ -23,35 +26,22 @@ module.exports = function(grunt) {
       }
     },
 
-    // Before generating any new files, remove any previously-created files.
-    clean: {
-      tests: ['tmp']
-    },
-
-    // Configuration to be run (and then tested).
-    watch_exec: {
-      default_options: {
-        options: {
-        },
-        files: {
-          'tmp/default_options': ['test/fixtures/testing', 'test/fixtures/123']
-        }
-      },
-      custom_options: {
-        options: {
-          separator: ': ',
-          punctuation: ' !!!'
-        },
-        files: {
-          'tmp/custom_options': ['test/fixtures/testing', 'test/fixtures/123']
-        }
-      }
-    },
-
-    // Unit tests.
     nodeunit: {
       tests: ['test/*_test.js']
     }
+
+    // Configuration to be tested
+    watch_exec: {
+      echo: {
+        command: 'echo',
+        files: {
+          '+(app|lib)/**/*.rb': function(filepath) {
+            return 'spec/' + filepath.slice(0, -3) + '_spec.rb';
+          },
+          'spec/**/*.rb': true
+        }
+      }
+    },
 
   });
 

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Gale Shafer
+Copyright (c) 2015 Squaremouth
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "^0.9.2",
+    "gaze": "^0.5.1",
+    "grunt": "~0.4.5",
     "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-nodeunit": "^0.3.3",
-    "grunt": "~0.4.5"
+    "grunt-contrib-jshint": "^0.9.2",
+    "grunt-contrib-nodeunit": "^0.3.3"
   },
   "peerDependencies": {
     "grunt": "~0.4.5"


### PR DESCRIPTION
This commit moves the `grunt-watch-exec` code that was in the viper repo
and moves it into this repo. This commit also cleans up the grunt config
and changes the copyrights to Squaremouth instead of Gale. This commit
also breaks the tests because they were the generated tests and not
tests specific to the `grunt-watch-exec` plugin. We should clean up and
create valid tests for this plugin.

[38469757361489](https://app.asana.com/0/38469757361489/38469757361489)
